### PR TITLE
Add openiap-bootstrap helper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "./crates/proto",
     "./crates/client",
     "./crates/clib",
-    "./crates/cli"
+    "./crates/cli",
+    "./crates/bootstrap"
 ]
 
 # [profile.release]

--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,14 @@ cp target/x86_64-pc-windows-gnu/release/openiap.exe target/cli/windows-x64-openi
 cross build --target i686-pc-windows-gnu -v --release && cp target/i686-pc-windows-gnu/release/openiap_clib.dll target/lib/openiap-windows-i686.dll
 cp target/i686-pc-windows-gnu/release/openiap.exe target/cli/windows-i686-openiap.exe
 
+# build bootstrap helper for each target
+cross build --target x86_64-unknown-linux-gnu --release -p openiap-bootstrap && cp target/x86_64-unknown-linux-gnu/release/openiap-bootstrap target/cli/linux-x64-bootstrap
+cross build --target aarch64-unknown-linux-gnu --release -p openiap-bootstrap && cp target/aarch64-unknown-linux-gnu/release/openiap-bootstrap target/cli/linux-arm64-bootstrap
+cross build --target x86_64-apple-darwin --release -p openiap-bootstrap && cp target/x86_64-apple-darwin/release/openiap-bootstrap target/cli/macos-x64-bootstrap
+cross build --target aarch64-apple-darwin --release -p openiap-bootstrap && cp target/aarch64-apple-darwin/release/openiap-bootstrap target/cli/macos-arm64-bootstrap
+cross build --target x86_64-pc-windows-gnu --release -p openiap-bootstrap && cp target/x86_64-pc-windows-gnu/release/openiap-bootstrap.exe target/cli/windows-x64-bootstrap.exe
+cross build --target i686-pc-windows-gnu --release -p openiap-bootstrap && cp target/i686-pc-windows-gnu/release/openiap-bootstrap.exe target/cli/windows-i686-bootstrap.exe
+
 echo "done"
 # cross build --target aarch64-pc-windows-msvc --release && cp target/aarch64-pc-windows-msvc/release/openiap.dll target/lib/openiap-windows-arm64.dll
 

--- a/crates/bootstrap/Cargo.toml
+++ b/crates/bootstrap/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "openiap-bootstrap"
+version = "0.1.0"
+edition = "2021"
+description = "Bootstrap helper for downloading OpenIAP shared library"
+
+[dependencies]
+clap = { version = "4.5.4", features = ["derive"] }
+reqwest = { version = "0.11", features = ["blocking", "rustls-tls"] }
+anyhow = "1.0"

--- a/crates/bootstrap/src/main.rs
+++ b/crates/bootstrap/src/main.rs
@@ -1,0 +1,51 @@
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+struct Args {
+    /// Directory to place the downloaded library in
+    #[arg(long, default_value = "lib")]
+    dir: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+    let lib_name = match (os, arch) {
+        ("windows", "x86") => "openiap-windows-i686.dll",
+        ("windows", "x86_64") => "openiap-windows-x64.dll",
+        ("windows", "aarch64") => "openiap-windows-arm64.dll",
+        ("linux", "x86_64") => "libopeniap-linux-x64.so",
+        ("linux", "aarch64") => "libopeniap-linux-arm64.so",
+        ("macos", "x86_64") => "libopeniap-macos-x64.dylib",
+        ("macos", "aarch64") => "libopeniap-macos-arm64.dylib",
+        ("freebsd", "x86_64") => "libopeniap-freebsd-x64.so",
+        _ => return Err(anyhow!("Unsupported platform {}-{}", os, arch)),
+    };
+
+    let url = format!(
+        "https://github.com/openiap/rustapi/releases/latest/download/{}",
+        lib_name
+    );
+
+    fs::create_dir_all(&args.dir)?;
+    let dest = args.dir.join(lib_name);
+    if dest.exists() {
+        println!("library already present at {}", dest.display());
+        return Ok(());
+    }
+
+    println!("downloading {} to {}", url, dest.display());
+    let response = reqwest::blocking::get(&url)?;
+    if !response.status().is_success() {
+        return Err(anyhow!("failed downloading: {}", response.status()));
+    }
+    let bytes = response.bytes()?;
+    fs::write(&dest, &bytes)?;
+    println!("downloaded {} bytes", bytes.len());
+    Ok(())
+}

--- a/dotnet/Client.cs
+++ b/dotnet/Client.cs
@@ -869,6 +869,16 @@ namespace OpenIAP
             {
                 throw new PlatformNotSupportedException("Unsupported OS platform");
             }
+            try
+            {
+                var dir = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "lib");
+                if(!System.IO.File.Exists(System.IO.Path.Combine(dir, libfile)))
+                {
+                    var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("openiap-bootstrap", "--dir " + dir) { RedirectStandardOutput = false, RedirectStandardError = false });
+                    p?.WaitForExit();
+                }
+            }
+            catch { }
             if(dumpLoadingPaths) Console.WriteLine("****************************");
             if(dumpLoadingPaths) Console.WriteLine($"Loading library {libfile} for {Environment.OSVersion.Platform} ({arc})");
 

--- a/node/install.js
+++ b/node/install.js
@@ -1,0 +1,13 @@
+const { execFileSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const dir = path.join(__dirname, 'lib');
+if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+}
+try {
+    execFileSync('openiap-bootstrap', ['--dir', dir], { stdio: 'inherit' });
+} catch (e) {
+    console.warn('openiap-bootstrap failed', e);
+}

--- a/node/lib.js
+++ b/node/lib.js
@@ -652,6 +652,13 @@ function loadLibrary() {
             throw new Error(`Unsupported platform ${platform}`)
     }
     if (!fs.existsSync(libPath)) {
+        try {
+            require('child_process').execFileSync('openiap-bootstrap', ['--dir', libDir], { stdio: 'inherit' });
+        } catch (e) {
+            console.warn('openiap-bootstrap failed', e);
+        }
+    }
+    if (!fs.existsSync(libPath)) {
         libDir = path.join(__dirname, '../target/debug/');
         switch (process.platform) {
             case 'win32':

--- a/node/package.json
+++ b/node/package.json
@@ -5,7 +5,8 @@
   "main": "lib.js",
   "types": "lib.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "postinstall": "node install.js"
   },
   "keywords": [
     "openiap",

--- a/python/openiap/main.py
+++ b/python/openiap/main.py
@@ -2,6 +2,7 @@ import ctypes
 import json
 import os, platform
 import sys
+import subprocess
 from ctypes import (CDLL, Structure, c_char_p, c_void_p, c_bool, c_int, 
                    c_uint64, c_int64, c_double, CFUNCTYPE, POINTER, byref, pointer)
 import threading
@@ -595,6 +596,11 @@ class Client:
             raise LibraryLoadError("Unsupported platform " + sys.platform)
         
         lib_path = os.path.join(lib_dir, lib_file)
+        if not os.path.exists(lib_path):
+            try:
+                subprocess.run(["openiap-bootstrap", "--dir", lib_dir], check=True)
+            except Exception as e:
+                print("openiap-bootstrap failed", e)
         if not os.path.exists(lib_path):
             lib_dir = os.path.join(os.path.dirname(__file__), '..', 'lib')
             lib_path = os.path.join(lib_dir, lib_file)

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,4 +1,6 @@
 from setuptools import setup, find_packages
+import subprocess
+import os
 
 setup(
     name="openiap",
@@ -22,3 +24,10 @@ setup(
             ]
     },
 )
+
+lib_dir = os.path.join(os.path.dirname(__file__), 'openiap', 'lib')
+os.makedirs(lib_dir, exist_ok=True)
+try:
+    subprocess.run(['openiap-bootstrap', '--dir', lib_dir], check=False)
+except Exception:
+    pass


### PR DESCRIPTION
## Summary
- add new crate `openiap-bootstrap` that downloads the right library for the host OS and architecture
- integrate bootstrap into Node, Python and .NET so the library is fetched automatically
- build bootstrap for multiple targets in `build.sh`