### PR TITLE
Add workitem queue FFI functions (add, update, delete)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,10 @@
       "Bash(cargo:*)",
       "Bash(protoc:*)",
       "Bash(cmd.exe /c \"rustc --version\")",
-      "Bash(cmd.exe /c \"cargo --version\")"
+      "Bash(cmd.exe /c \"cargo --version\")",
+      "Bash(python -m build:*)",
+      "Bash(cmd.exe /c \"cd /d c:\\\\dev\\\\Customer\\\\openiap\\\\rustapi\\\\python && python -m build\")",
+      "Bash(cmd.exe /c \"cd /d c:\\\\dev\\\\Customer\\\\openiap\\\\rustapi\\\\python && python -m build 2>&1\")"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(rustc --version:*)",
+      "Bash(cargo:*)",
+      "Bash(protoc:*)",
+      "Bash(cmd.exe /c \"rustc --version\")",
+      "Bash(cmd.exe /c \"cargo --version\")"
+    ]
+  }
+}

--- a/crates/clib/clib_openiap.h
+++ b/crates/clib/clib_openiap.h
@@ -629,6 +629,101 @@ typedef struct InvokeOpenRPARequestWrapper {
   int32_t request_id;
 } InvokeOpenRPARequestWrapper;
 
+/**
+ * WorkItemQueueWrapper is a C-compatible wrapper for WorkItemQueue
+ */
+typedef struct WorkItemQueueWrapper {
+  const char *workflowid;
+  const char *robotqueue;
+  const char *amqpqueue;
+  const char *projectid;
+  const char *usersrole;
+  int32_t maxretries;
+  int32_t retrydelay;
+  int32_t initialdelay;
+  const char *success_wiqid;
+  const char *failed_wiqid;
+  const char *success_wiq;
+  const char *failed_wiq;
+  const char *id;
+  const char *name;
+  const char *packageid;
+  int32_t request_id;
+} WorkItemQueueWrapper;
+
+/**
+ * AddWorkItemQueueResponseWrapper is a C-compatible wrapper for AddWorkItemQueueResponse
+ */
+typedef struct AddWorkItemQueueResponseWrapper {
+  bool success;
+  const char *error;
+  const struct WorkItemQueueWrapper *workitemqueue;
+  int32_t request_id;
+} AddWorkItemQueueResponseWrapper;
+
+/**
+ * AddWorkItemQueueRequestWrapper is a C-compatible wrapper for AddWorkItemQueueRequest
+ */
+typedef struct AddWorkItemQueueRequestWrapper {
+  const struct WorkItemQueueWrapper *workitemqueue;
+  bool skiprole;
+  int32_t request_id;
+} AddWorkItemQueueRequestWrapper;
+
+/**
+ * Callback type for add_workitem_queue_async
+ */
+typedef void (*AddWorkItemQueueCallback)(struct AddWorkItemQueueResponseWrapper *wrapper);
+
+/**
+ * UpdateWorkItemQueueResponseWrapper is a C-compatible wrapper for UpdateWorkItemQueueResponse
+ */
+typedef struct UpdateWorkItemQueueResponseWrapper {
+  bool success;
+  const char *error;
+  const struct WorkItemQueueWrapper *workitemqueue;
+  int32_t request_id;
+} UpdateWorkItemQueueResponseWrapper;
+
+/**
+ * UpdateWorkItemQueueRequestWrapper is a C-compatible wrapper for UpdateWorkItemQueueRequest
+ */
+typedef struct UpdateWorkItemQueueRequestWrapper {
+  const struct WorkItemQueueWrapper *workitemqueue;
+  bool skiprole;
+  bool purge;
+  int32_t request_id;
+} UpdateWorkItemQueueRequestWrapper;
+
+/**
+ * Callback type for update_workitem_queue_async
+ */
+typedef void (*UpdateWorkItemQueueCallback)(struct UpdateWorkItemQueueResponseWrapper *wrapper);
+
+/**
+ * DeleteWorkItemQueueResponseWrapper is a C-compatible wrapper for DeleteWorkItemQueueResponse
+ */
+typedef struct DeleteWorkItemQueueResponseWrapper {
+  bool success;
+  const char *error;
+  int32_t request_id;
+} DeleteWorkItemQueueResponseWrapper;
+
+/**
+ * DeleteWorkItemQueueRequestWrapper is a C-compatible wrapper for DeleteWorkItemQueueRequest
+ */
+typedef struct DeleteWorkItemQueueRequestWrapper {
+  const char *wiq;
+  const char *wiqid;
+  bool purge;
+  int32_t request_id;
+} DeleteWorkItemQueueRequestWrapper;
+
+/**
+ * Callback type for delete_workitem_queue_async
+ */
+typedef void (*DeleteWorkItemQueueCallback)(struct DeleteWorkItemQueueResponseWrapper *wrapper);
+
 void error(const char *message);
 
 void info(const char *message);
@@ -1009,3 +1104,62 @@ struct InvokeOpenRPAResponseWrapper *invoke_openrpa(struct ClientWrapper *client
                                                     int32_t timeout);
 
 void free_invoke_openrpa_response(struct InvokeOpenRPAResponseWrapper *response);
+
+/**
+ * Synchronous add_workitem_queue FFI function
+ */
+struct AddWorkItemQueueResponseWrapper *add_workitem_queue(struct ClientWrapper *client,
+                                                           struct AddWorkItemQueueRequestWrapper *options);
+
+/**
+ * Asynchronous add_workitem_queue FFI function
+ */
+void add_workitem_queue_async(struct ClientWrapper *client,
+                              struct AddWorkItemQueueRequestWrapper *options,
+                              AddWorkItemQueueCallback callback);
+
+/**
+ * Free AddWorkItemQueueResponseWrapper
+ */
+void free_add_workitem_queue_response(struct AddWorkItemQueueResponseWrapper *response);
+
+/**
+ * Free WorkItemQueueWrapper
+ */
+void free_workitem_queue_wrapper(struct WorkItemQueueWrapper *wrapper);
+
+/**
+ * Synchronous update_workitem_queue FFI function
+ */
+struct UpdateWorkItemQueueResponseWrapper *update_workitem_queue(struct ClientWrapper *client,
+                                                                 struct UpdateWorkItemQueueRequestWrapper *options);
+
+/**
+ * Asynchronous update_workitem_queue FFI function
+ */
+void update_workitem_queue_async(struct ClientWrapper *client,
+                                 struct UpdateWorkItemQueueRequestWrapper *options,
+                                 UpdateWorkItemQueueCallback callback);
+
+/**
+ * Free UpdateWorkItemQueueResponseWrapper
+ */
+void free_update_workitem_queue_response(struct UpdateWorkItemQueueResponseWrapper *response);
+
+/**
+ * Synchronous delete_workitem_queue FFI function
+ */
+struct DeleteWorkItemQueueResponseWrapper *delete_workitem_queue(struct ClientWrapper *client,
+                                                                 struct DeleteWorkItemQueueRequestWrapper *options);
+
+/**
+ * Asynchronous delete_workitem_queue FFI function
+ */
+void delete_workitem_queue_async(struct ClientWrapper *client,
+                                 struct DeleteWorkItemQueueRequestWrapper *options,
+                                 DeleteWorkItemQueueCallback callback);
+
+/**
+ * Free DeleteWorkItemQueueResponseWrapper
+ */
+void free_delete_workitem_queue_response(struct DeleteWorkItemQueueResponseWrapper *response);

--- a/crates/clib/clib_openiap.h
+++ b/crates/clib/clib_openiap.h
@@ -630,6 +630,15 @@ typedef struct InvokeOpenRPARequestWrapper {
 } InvokeOpenRPARequestWrapper;
 
 /**
+ * AceWrapper is a C-compatible wrapper for Access Control Entry (Ace)
+ */
+typedef struct AceWrapper {
+  const char *id;
+  bool deny;
+  int32_t rights;
+} AceWrapper;
+
+/**
  * WorkItemQueueWrapper is a C-compatible wrapper for WorkItemQueue
  */
 typedef struct WorkItemQueueWrapper {
@@ -648,6 +657,8 @@ typedef struct WorkItemQueueWrapper {
   const char *id;
   const char *name;
   const char *packageid;
+  const struct AceWrapper *const *acl;
+  int32_t acl_len;
   int32_t request_id;
 } WorkItemQueueWrapper;
 

--- a/crates/clib/src/lib.rs
+++ b/crates/clib/src/lib.rs
@@ -7,7 +7,7 @@ use openiap_client::openiap::{
     QueryRequest, SigninRequest, UploadRequest, WatchEvent, WatchRequest,
 };
 use openiap_client::{Client, ClientEvent, CreateCollectionRequest, CreateIndexRequest, CustomCommandRequest, DeleteManyRequest, DeleteOneRequest, DeleteWorkitemRequest, DropCollectionRequest, DropIndexRequest, GetIndexesRequest, InsertManyRequest, InsertOrUpdateOneRequest, InvokeOpenRpaRequest, PopWorkitemRequest, PushWorkitemRequest, QueueEvent, QueueMessageRequest, RegisterExchangeRequest, RegisterQueueRequest, Timestamp, UpdateOneRequest, UpdateWorkitemRequest, Workitem, WorkitemFile};
-use openiap_client::openiap::{AddWorkItemQueueRequest, UpdateWorkItemQueueRequest, DeleteWorkItemQueueRequest, WorkItemQueue, Ace};
+use openiap_client::openiap::{AddWorkItemQueueRequest, UpdateWorkItemQueueRequest, DeleteWorkItemQueueRequest, WorkItemQueue};
 
 #[cfg(all(test, not(windows)))]
 mod tests;

--- a/python/openiap/main.py
+++ b/python/openiap/main.py
@@ -1669,7 +1669,7 @@ class Client:
                                         wiqid=c_char_p(wiqid.encode('utf-8')))
         
         self.trace("Calling pop_workitem_async")
-        self.lib.pop_workitem_async(self.client, byref(req), downloadfolder, cb)
+        self.lib.pop_workitem_async(self.client, byref(req), downloadfolder.encode('utf-8'), cb)
         self.trace("pop_workitem_async called")
 
         event.wait()

--- a/python/openiap/main.py
+++ b/python/openiap/main.py
@@ -2154,6 +2154,298 @@ class Client:
         self.lib.free_invoke_openrpa_response(ref)
         return result
 
+    def add_workitem_queue(self, name, workflowid="", robotqueue="", amqpqueue="", projectid="",
+                           usersrole="", maxretries=3, retrydelay=0, initialdelay=0,
+                           success_wiqid="", failed_wiqid="", success_wiq="", failed_wiq="",
+                           skiprole=False, packageid=""):
+        """
+        Add a new workitem queue.
+        :param name: str - Name of the workitem queue
+        :param workflowid: str - Workflow ID
+        :param robotqueue: str - Robot queue name
+        :param amqpqueue: str - AMQP queue name
+        :param projectid: str - Project ID
+        :param usersrole: str - Users role
+        :param maxretries: int - Maximum retries
+        :param retrydelay: int - Retry delay in seconds
+        :param initialdelay: int - Initial delay in seconds
+        :param success_wiqid: str - Success workitem queue ID
+        :param failed_wiqid: str - Failed workitem queue ID
+        :param success_wiq: str - Success workitem queue name
+        :param failed_wiq: str - Failed workitem queue name
+        :param skiprole: bool - Skip role creation
+        :param packageid: str - Package ID
+        :return: dict with workitem queue details
+        :raises: ClientError
+        """
+        self.trace("Inside add_workitem_queue")
+
+        class WorkItemQueueWrapper(ctypes.Structure):
+            _fields_ = [
+                ("workflowid", c_char_p),
+                ("robotqueue", c_char_p),
+                ("amqpqueue", c_char_p),
+                ("projectid", c_char_p),
+                ("usersrole", c_char_p),
+                ("maxretries", c_int),
+                ("retrydelay", c_int),
+                ("initialdelay", c_int),
+                ("success_wiqid", c_char_p),
+                ("failed_wiqid", c_char_p),
+                ("success_wiq", c_char_p),
+                ("failed_wiq", c_char_p),
+                ("id", c_char_p),
+                ("name", c_char_p),
+                ("packageid", c_char_p),
+                ("request_id", c_int)
+            ]
+
+        class AddWorkItemQueueRequestWrapper(ctypes.Structure):
+            _fields_ = [
+                ("workitemqueue", ctypes.POINTER(WorkItemQueueWrapper)),
+                ("skiprole", c_bool),
+                ("request_id", c_int)
+            ]
+
+        class AddWorkItemQueueResponseWrapper(ctypes.Structure):
+            _fields_ = [
+                ("success", c_bool),
+                ("error", c_char_p),
+                ("workitemqueue", ctypes.POINTER(WorkItemQueueWrapper)),
+                ("request_id", c_int)
+            ]
+
+        wiq = WorkItemQueueWrapper(
+            workflowid=workflowid.encode('utf-8'),
+            robotqueue=robotqueue.encode('utf-8'),
+            amqpqueue=amqpqueue.encode('utf-8'),
+            projectid=projectid.encode('utf-8'),
+            usersrole=usersrole.encode('utf-8'),
+            maxretries=maxretries,
+            retrydelay=retrydelay,
+            initialdelay=initialdelay,
+            success_wiqid=success_wiqid.encode('utf-8'),
+            failed_wiqid=failed_wiqid.encode('utf-8'),
+            success_wiq=success_wiq.encode('utf-8'),
+            failed_wiq=failed_wiq.encode('utf-8'),
+            id=b'',
+            name=name.encode('utf-8'),
+            packageid=packageid.encode('utf-8'),
+            request_id=0
+        )
+
+        req = AddWorkItemQueueRequestWrapper(
+            workitemqueue=ctypes.pointer(wiq),
+            skiprole=skiprole,
+            request_id=0
+        )
+
+        self.lib.add_workitem_queue.argtypes = [c_void_p, ctypes.POINTER(AddWorkItemQueueRequestWrapper)]
+        self.lib.add_workitem_queue.restype = ctypes.POINTER(AddWorkItemQueueResponseWrapper)
+
+        self.trace("Calling add_workitem_queue")
+        ref = self.lib.add_workitem_queue(self.client, ctypes.byref(req))
+        response = ref.contents
+
+        if not response.success:
+            error_message = response.error.decode('utf-8') if response.error else 'Unknown error'
+            self.lib.free_add_workitem_queue_response(ref)
+            raise ClientError(f"Add workitem queue failed: {error_message}")
+
+        result_wiq = response.workitemqueue.contents
+        result = {
+            "id": result_wiq.id.decode('utf-8') if result_wiq.id else "",
+            "name": result_wiq.name.decode('utf-8') if result_wiq.name else "",
+            "workflowid": result_wiq.workflowid.decode('utf-8') if result_wiq.workflowid else "",
+            "robotqueue": result_wiq.robotqueue.decode('utf-8') if result_wiq.robotqueue else "",
+            "amqpqueue": result_wiq.amqpqueue.decode('utf-8') if result_wiq.amqpqueue else "",
+            "projectid": result_wiq.projectid.decode('utf-8') if result_wiq.projectid else "",
+            "usersrole": result_wiq.usersrole.decode('utf-8') if result_wiq.usersrole else "",
+            "maxretries": result_wiq.maxretries,
+            "retrydelay": result_wiq.retrydelay,
+            "initialdelay": result_wiq.initialdelay,
+            "success_wiqid": result_wiq.success_wiqid.decode('utf-8') if result_wiq.success_wiqid else "",
+            "failed_wiqid": result_wiq.failed_wiqid.decode('utf-8') if result_wiq.failed_wiqid else "",
+            "success_wiq": result_wiq.success_wiq.decode('utf-8') if result_wiq.success_wiq else "",
+            "failed_wiq": result_wiq.failed_wiq.decode('utf-8') if result_wiq.failed_wiq else "",
+            "packageid": result_wiq.packageid.decode('utf-8') if result_wiq.packageid else "",
+        }
+
+        self.lib.free_add_workitem_queue_response(ref)
+        return result
+
+    def update_workitem_queue(self, id, name="", workflowid="", robotqueue="", amqpqueue="", projectid="",
+                              usersrole="", maxretries=3, retrydelay=0, initialdelay=0,
+                              success_wiqid="", failed_wiqid="", success_wiq="", failed_wiq="",
+                              skiprole=False, purge=False, packageid=""):
+        """
+        Update an existing workitem queue.
+        :param id: str - ID of the workitem queue to update
+        :param name: str - Name of the workitem queue
+        :param workflowid: str - Workflow ID
+        :param robotqueue: str - Robot queue name
+        :param amqpqueue: str - AMQP queue name
+        :param projectid: str - Project ID
+        :param usersrole: str - Users role
+        :param maxretries: int - Maximum retries
+        :param retrydelay: int - Retry delay in seconds
+        :param initialdelay: int - Initial delay in seconds
+        :param success_wiqid: str - Success workitem queue ID
+        :param failed_wiqid: str - Failed workitem queue ID
+        :param success_wiq: str - Success workitem queue name
+        :param failed_wiq: str - Failed workitem queue name
+        :param skiprole: bool - Skip role creation
+        :param purge: bool - Purge all workitems in the queue
+        :param packageid: str - Package ID
+        :return: dict with workitem queue details
+        :raises: ClientError
+        """
+        self.trace("Inside update_workitem_queue")
+
+        class WorkItemQueueWrapper(ctypes.Structure):
+            _fields_ = [
+                ("workflowid", c_char_p),
+                ("robotqueue", c_char_p),
+                ("amqpqueue", c_char_p),
+                ("projectid", c_char_p),
+                ("usersrole", c_char_p),
+                ("maxretries", c_int),
+                ("retrydelay", c_int),
+                ("initialdelay", c_int),
+                ("success_wiqid", c_char_p),
+                ("failed_wiqid", c_char_p),
+                ("success_wiq", c_char_p),
+                ("failed_wiq", c_char_p),
+                ("id", c_char_p),
+                ("name", c_char_p),
+                ("packageid", c_char_p),
+                ("request_id", c_int)
+            ]
+
+        class UpdateWorkItemQueueRequestWrapper(ctypes.Structure):
+            _fields_ = [
+                ("workitemqueue", ctypes.POINTER(WorkItemQueueWrapper)),
+                ("skiprole", c_bool),
+                ("purge", c_bool),
+                ("request_id", c_int)
+            ]
+
+        class UpdateWorkItemQueueResponseWrapper(ctypes.Structure):
+            _fields_ = [
+                ("success", c_bool),
+                ("error", c_char_p),
+                ("workitemqueue", ctypes.POINTER(WorkItemQueueWrapper)),
+                ("request_id", c_int)
+            ]
+
+        wiq = WorkItemQueueWrapper(
+            workflowid=workflowid.encode('utf-8'),
+            robotqueue=robotqueue.encode('utf-8'),
+            amqpqueue=amqpqueue.encode('utf-8'),
+            projectid=projectid.encode('utf-8'),
+            usersrole=usersrole.encode('utf-8'),
+            maxretries=maxretries,
+            retrydelay=retrydelay,
+            initialdelay=initialdelay,
+            success_wiqid=success_wiqid.encode('utf-8'),
+            failed_wiqid=failed_wiqid.encode('utf-8'),
+            success_wiq=success_wiq.encode('utf-8'),
+            failed_wiq=failed_wiq.encode('utf-8'),
+            id=id.encode('utf-8'),
+            name=name.encode('utf-8'),
+            packageid=packageid.encode('utf-8'),
+            request_id=0
+        )
+
+        req = UpdateWorkItemQueueRequestWrapper(
+            workitemqueue=ctypes.pointer(wiq),
+            skiprole=skiprole,
+            purge=purge,
+            request_id=0
+        )
+
+        self.lib.update_workitem_queue.argtypes = [c_void_p, ctypes.POINTER(UpdateWorkItemQueueRequestWrapper)]
+        self.lib.update_workitem_queue.restype = ctypes.POINTER(UpdateWorkItemQueueResponseWrapper)
+
+        self.trace("Calling update_workitem_queue")
+        ref = self.lib.update_workitem_queue(self.client, ctypes.byref(req))
+        response = ref.contents
+
+        if not response.success:
+            error_message = response.error.decode('utf-8') if response.error else 'Unknown error'
+            self.lib.free_update_workitem_queue_response(ref)
+            raise ClientError(f"Update workitem queue failed: {error_message}")
+
+        result_wiq = response.workitemqueue.contents
+        result = {
+            "id": result_wiq.id.decode('utf-8') if result_wiq.id else "",
+            "name": result_wiq.name.decode('utf-8') if result_wiq.name else "",
+            "workflowid": result_wiq.workflowid.decode('utf-8') if result_wiq.workflowid else "",
+            "robotqueue": result_wiq.robotqueue.decode('utf-8') if result_wiq.robotqueue else "",
+            "amqpqueue": result_wiq.amqpqueue.decode('utf-8') if result_wiq.amqpqueue else "",
+            "projectid": result_wiq.projectid.decode('utf-8') if result_wiq.projectid else "",
+            "usersrole": result_wiq.usersrole.decode('utf-8') if result_wiq.usersrole else "",
+            "maxretries": result_wiq.maxretries,
+            "retrydelay": result_wiq.retrydelay,
+            "initialdelay": result_wiq.initialdelay,
+            "success_wiqid": result_wiq.success_wiqid.decode('utf-8') if result_wiq.success_wiqid else "",
+            "failed_wiqid": result_wiq.failed_wiqid.decode('utf-8') if result_wiq.failed_wiqid else "",
+            "success_wiq": result_wiq.success_wiq.decode('utf-8') if result_wiq.success_wiq else "",
+            "failed_wiq": result_wiq.failed_wiq.decode('utf-8') if result_wiq.failed_wiq else "",
+            "packageid": result_wiq.packageid.decode('utf-8') if result_wiq.packageid else "",
+        }
+
+        self.lib.free_update_workitem_queue_response(ref)
+        return result
+
+    def delete_workitem_queue(self, wiq="", wiqid="", purge=False):
+        """
+        Delete a workitem queue.
+        :param wiq: str - Name of the workitem queue to delete
+        :param wiqid: str - ID of the workitem queue to delete
+        :param purge: bool - Purge all workitems in the queue
+        :return: bool - True if successful
+        :raises: ClientError
+        """
+        self.trace("Inside delete_workitem_queue")
+
+        class DeleteWorkItemQueueRequestWrapper(ctypes.Structure):
+            _fields_ = [
+                ("wiq", c_char_p),
+                ("wiqid", c_char_p),
+                ("purge", c_bool),
+                ("request_id", c_int)
+            ]
+
+        class DeleteWorkItemQueueResponseWrapper(ctypes.Structure):
+            _fields_ = [
+                ("success", c_bool),
+                ("error", c_char_p),
+                ("request_id", c_int)
+            ]
+
+        req = DeleteWorkItemQueueRequestWrapper(
+            wiq=wiq.encode('utf-8'),
+            wiqid=wiqid.encode('utf-8'),
+            purge=purge,
+            request_id=0
+        )
+
+        self.lib.delete_workitem_queue.argtypes = [c_void_p, ctypes.POINTER(DeleteWorkItemQueueRequestWrapper)]
+        self.lib.delete_workitem_queue.restype = ctypes.POINTER(DeleteWorkItemQueueResponseWrapper)
+
+        self.trace("Calling delete_workitem_queue")
+        ref = self.lib.delete_workitem_queue(self.client, ctypes.byref(req))
+        response = ref.contents
+
+        if not response.success:
+            error_message = response.error.decode('utf-8') if response.error else 'Unknown error'
+            self.lib.free_delete_workitem_queue_response(ref)
+            raise ClientError(f"Delete workitem queue failed: {error_message}")
+
+        self.lib.free_delete_workitem_queue_response(ref)
+        return True
+
     def __del__(self):
         if hasattr(self, 'lib'):
             self.lib.free_client.argtypes = [POINTER(ClientWrapper)]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openiap-edge"
-version = "0.0.41"
+version = "0.0.42"
 authors = [
   { name="OpenIAP ApS / Allan Zimmerman", email="info@openiap.io" },
 ]

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="openiap",
-    version="0.0.41",
+    version="0.0.42",
     author="OpenIAP ApS / Allan Zimmerman",
     author_email="info@openiap.io",
     description="Simple openiap api wrapper using proto",

--- a/python/test.py
+++ b/python/test.py
@@ -83,6 +83,33 @@ if __name__ == "__main__":
         workitem["state"] = "successful"
         client.update_workitem(workitem, files)
 
+        # Test workitem queue CRUD operations
+        print("*********************************")
+        print("Testing workitem queue CRUD operations")
+        print("*********************************")
+
+        # Add a new workitem queue
+        wiq_result = client.add_workitem_queue(
+            name="python_test_wiq",
+            maxretries=5,
+            retrydelay=60,
+            initialdelay=0
+        )
+        print("Created workitem queue:", wiq_result)
+        wiq_id = wiq_result["id"]
+
+        # Update the workitem queue
+        updated_wiq = client.update_workitem_queue(
+            id=wiq_id,
+            name="python_test_wiq_updated",
+            maxretries=10,
+            retrydelay=120
+        )
+        print("Updated workitem queue:", updated_wiq)
+
+        # Delete the workitem queue
+        delete_result = client.delete_workitem_queue(wiqid=wiq_id, purge=True)
+        print("Deleted workitem queue:", delete_result)
 
         query_result = client.query(collectionname="entities", query="{}", projection="{\"name\": 1}", orderby="", queryas="", explain=False, skip=0, top=0)
         print(query_result)


### PR DESCRIPTION
## Summary

- Add FFI wrapper structs and functions for workitem queue CRUD operations in `crates/clib/src/lib.rs`
- Add Python ctypes bindings for `add_workitem_queue`, `update_workitem_queue`, and `delete_workitem_queue` in `python/openiap/main.py`
- Add tests for workitem queue operations in `python/test.py`

## Changes

### Rust FFI Layer (`crates/clib/src/lib.rs`)
- `WorkItemQueueWrapper` struct with C-compatible layout
- `add_workitem_queue` / `add_workitem_queue_async` - Create new workitem queues
- `update_workitem_queue` / `update_workitem_queue_async` - Update existing workitem queues
- `delete_workitem_queue` / `delete_workitem_queue_async` - Delete workitem queues with optional purge
- Corresponding `free_*` functions for memory management

### Python Bindings (`python/openiap/main.py`)
- `add_workitem_queue()` - Create workitem queue with configurable options (maxretries, retrydelay, initialdelay, etc.)
- `update_workitem_queue()` - Update workitem queue properties
- `delete_workitem_queue()` - Delete workitem queue with optional purge flag

### Tests (`python/test.py`)
- Full CRUD cycle test: create → update → delete workitem queue

## Test plan

- [x] Cargo build passes without warnings
- [x] Python wheel builds successfully
- [x] Tested locally against OpenIAP instance:
  - [x] Create workitem queue
  - [x] Update workitem queue
  - [x] Delete workitem queue with purge

🤖 Generated with [Claude Code](https://claude.com/claude-code)